### PR TITLE
Kubernetes metadata enrichment (#9)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,18 +27,18 @@ These can be modified via the `--log-opt KEY=VALUE` command-line argument when u
 In git root, run:
 [,bash]
 ----
-$ cd plugin && chmod +rwx ./plugin-build && make all
+$ chmod +x build.sh && bash build.sh
 ----
 Will make the plugin and enable it. You can check if it was successful with the `docker plugin ls` command.
 The plugin's logs can be accessed from the `/run/docker/plugins/<id>/` folder.
 
 == Running the plugin with a container
 
-To attach the log driver to a container, run the container with the `--log-driver:teragrep/dkr_01:v1` parameter.
+To attach the log driver to a container, run the container with the `--log-driver=teragrep/dkr_01:v1` parameter.
 [,bash]
 ----
-$ docker run --log-driver:teragrep/dkr_01:v1 \
-    --log-opt relpHostname=1.2.3.4 \
+$ docker run --log-driver=teragrep/dkr_01:v1 \
+    --log-opt relpHostname=127.0.0.1 \
     --log-opt relpPort=1234 \
     --log-opt relpTls=false
 ----
@@ -51,7 +51,7 @@ If using the `docker-compose` command, you can customize the `docker-compose.yam
 x-logging:
     &default-logging
     options:
-        relpHostname: "1.2.3.4"
+        relpHostname: "127.0.0.1"
         relpPort: "1601"
     driver: teragrep/dkr_01:v1
 services:

--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,18 @@ These can be modified via the `--log-opt KEY=VALUE` command-line argument when u
 * relpHostname = ip address
 * relpPort = port number
 * relpTls = "true" or "false"
+* syslogHostname = used for hostname in the syslog message, otherwise actual system hostname
+* syslogAppName = used for app name in the syslog message, otherwise "teragrep"
+* tags = "off", "minimal" or "full", sets additional structured data based on docker log tags
+* k8sMetadata = "true" or "false", fetch kubernetes metadata from specified address
+* kubeletUrl = "https://xxx:12345", provide kubelet address for kubernetes metadata
+* k8sClientAuthEnabled = "true" or "false"
+* k8sClientAuthCertPath = "..."
+* k8sClientAuthKeyPath = "..."
+* k8sServerCertValidationEnabled = "true" or "false"
+* k8sServerCertPath = "..."
+* k8sMetadataRefreshInterval = "0" in seconds
+* k8sMetadataRefreshEnabled = "true" or "false"
 
 == Building the plugin
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "dkr_01 build script start"
+# move to /plugin dir
+cd plugin || exit 1
+
+# check for plugin-build's existence and make it read-writable if it exists
+if [ -d ./plugin-build ]
+then
+  chmod -R +rw ./plugin-build
+fi
+# run make all
+make all
+echo "dkr_01 build script done"

--- a/plugin/kubernetesAPI.go
+++ b/plugin/kubernetesAPI.go
@@ -8,8 +8,11 @@ import (
 )
 
 type KubernetesAPI struct {
-	clientKeyPath  string
-	clientCertPath string
+	clientKeyPath     string
+	clientCertPath    string
+	serverCertPath    string
+	clientAuthEnabled bool
+	serverAuthEnabled bool
 	// url should be in form of "https://localhost:10250"
 	url             string
 	data            *map[string]interface{}
@@ -37,7 +40,7 @@ func (kapi *KubernetesAPI) FetchData() error {
 	return nil
 }
 
-func (kapi *KubernetesAPI) GetContainerData(cntid string) error {
+func (kapi *KubernetesAPI) GetContainerData(cntId string) error {
 	// check if data has been fetched
 	if kapi.data == nil {
 		return errors.New("KubernetesAPI data was nil, please retrieve data with FetchData() first")
@@ -56,8 +59,10 @@ func (kapi *KubernetesAPI) GetContainerData(cntid string) error {
 		statusItem := statuses[i]
 		if statusItem != nil {
 			idString := statusItem.(map[string]interface{})["containerID"].(string)
-			if idString == cntid {
+			if idString == cntId {
+				// matching container id
 				kapi.containerStatus = statusItem.(map[string]interface{})
+				break
 			}
 		}
 	}

--- a/plugin/kubernetesAPI.go
+++ b/plugin/kubernetesAPI.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+type KubernetesAPI struct {
+	clientKeyPath  string
+	clientCertPath string
+	// url should be in form of "https://localhost:10250"
+	url             string
+	data            *map[string]interface{}
+	metadata        map[string]string
+	containerStatus map[string]interface{}
+}
+
+func (kapi *KubernetesAPI) FetchData() error {
+	resp, err := http.Get(kapi.url + "/pods")
+	if err != nil {
+		return err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var objMap map[string]interface{}
+	if err := json.Unmarshal(body, &objMap); err != nil {
+		return err
+	}
+
+	kapi.data = &objMap
+	return nil
+}
+
+func (kapi *KubernetesAPI) GetContainerData(cntid string) error {
+	// check if data has been fetched
+	if kapi.data == nil {
+		return errors.New("KubernetesAPI data was nil, please retrieve data with FetchData() first")
+	}
+
+	// .items[] > status > containerStatuses[] > containerID
+	items, _ := (*kapi.data)["items"] // get "items" array
+	item := items.([]interface{})[0]  // get first item of "items" array
+
+	status := item.(map[string]interface{})["status"]                         // get "status" map
+	containerStatuses := status.(map[string]interface{})["containerStatuses"] // get "containerStatuses" array
+
+	// get status for container id
+	statuses := containerStatuses.([]interface{})
+	for i := 0; i < len(statuses); i++ {
+		statusItem := statuses[i]
+		if statusItem != nil {
+			idString := statusItem.(map[string]interface{})["containerID"].(string)
+			if idString == cntid {
+				kapi.containerStatus = statusItem.(map[string]interface{})
+			}
+		}
+	}
+
+	// prepare metadata map
+	kapi.metadata = make(map[string]string)
+
+	// .items[] > metadata > name
+	metadata := item.(map[string]interface{})["metadata"]
+	name := metadata.(map[string]interface{})["name"]
+	kapi.metadata["name"] = name.(string)
+	// .items[] > metadata > namespace
+	namespace := metadata.(map[string]interface{})["namespace"]
+	kapi.metadata["namespace"] = namespace.(string)
+	// .items[] > metadata > labels
+	labels := metadata.(map[string]interface{})["labels"]
+	jsonLabels, err := json.Marshal(&labels)
+	if err != nil {
+		jsonLabels = []byte("null")
+	}
+	kapi.metadata["labels"] = string(jsonLabels)
+	// .items[] > metadata > uid
+	uid := metadata.(map[string]interface{})["uid"]
+	kapi.metadata["uid"] = uid.(string)
+	// .items[] > metadata > creationTimestamp
+	creationTimestamp := metadata.(map[string]interface{})["creationTimestamp"]
+	if creationTimestamp != nil {
+		kapi.metadata["creationTimestamp"] = creationTimestamp.(string)
+	} else {
+		kapi.metadata["creationTimestamp"] = "null"
+	}
+
+	//fmt.Println(kapi.metadata)
+	//fmt.Println(kapi.containerStatus)
+
+	return nil
+}

--- a/plugin/kubernetesAPI.go
+++ b/plugin/kubernetesAPI.go
@@ -29,6 +29,19 @@ func (kapi *KubernetesAPI) FetchData() error {
 
 	// client certs
 	if kapi.clientAuthEnabled {
+		if _, err := os.Stat(kapi.clientCertPath); err == nil {
+			// client cert path exists
+			if _, err2 := os.Stat(kapi.clientKeyPath); err2 == nil {
+				// client key path exists
+			} else {
+				// client key path doesn't exist
+				return errors.New("client key path doesn't exist: '" + kapi.clientKeyPath + "'")
+			}
+		} else {
+			// client cert path doesn't exist
+			return errors.New("client cert path doesn't exist: '" + kapi.clientCertPath + "'")
+		}
+
 		cert, err := tls.LoadX509KeyPair(kapi.clientCertPath, kapi.clientKeyPath)
 		if err != nil {
 			return err
@@ -49,7 +62,7 @@ func (kapi *KubernetesAPI) FetchData() error {
 			tlsConfig.RootCAs = caCertPool
 
 		} else {
-			panic("Server cert path pointed to a file that does not exist: '" + kapi.serverCertPath + "'")
+			return errors.New("Server cert path pointed to a file that does not exist: '" + kapi.serverCertPath + "'")
 		}
 
 	}

--- a/plugin/logOptsValidator.go
+++ b/plugin/logOptsValidator.go
@@ -3,14 +3,22 @@ package main
 import "fmt"
 
 const (
-	RELP_HOSTNAME_OPT   = "relpHostname"
-	RELP_PORT_OPT       = "relpPort"
-	RELP_TLS_OPT        = "relpTls"
-	SYSLOG_HOSTNAME_OPT = "syslogHostname"
-	SYSLOG_APPNAME_OPT  = "syslogAppName"
-	DRIVER_NAME         = "teragrep-dkr_01"
-
-	TAG_OPT = "tags"
+	RELP_HOSTNAME_OPT                      = "relpHostname"
+	RELP_PORT_OPT                          = "relpPort"
+	RELP_TLS_OPT                           = "relpTls"
+	SYSLOG_HOSTNAME_OPT                    = "syslogHostname"
+	SYSLOG_APPNAME_OPT                     = "syslogAppName"
+	TAG_OPT                                = "tags"
+	K8S_METADATA_EXTRACTION_ENABLED_OPT    = "k8sMetadata"
+	KUBELET_URL_OPT                        = "kubeletUrl"
+	K8S_CLIENT_AUTH_ENABLED_OPT            = "k8sClientAuthEnabled"
+	K8S_CLIENT_AUTH_CERT_LOCATION_OPT      = "k8sClientAuthCertPath"
+	K8S_CLIENT_AUTH_KEY_LOCATION_OPT       = "k8sClientAuthKeyPath"
+	K8S_SERVER_CERT_VALIDATION_ENABLED_OPT = "k8sServerCertValidationEnabled"
+	K8S_SERVER_CERT_LOCATION_OPT           = "k8sServerCertPath"
+	K8S_METADATA_REFRESH_INTERVAL_OPT      = "k8sMetadataRefreshInterval"
+	K8S_METADATA_REFRESH_ENABLED_OPT       = "k8sMetadataRefreshEnabled"
+	DRIVER_NAME                            = "teragrep-dkr_01"
 )
 
 func ValidateLogOpts(cfg map[string]string) error {
@@ -22,6 +30,14 @@ func ValidateLogOpts(cfg map[string]string) error {
 		case SYSLOG_HOSTNAME_OPT:
 		case SYSLOG_APPNAME_OPT:
 		case TAG_OPT:
+		case K8S_METADATA_EXTRACTION_ENABLED_OPT:
+		case KUBELET_URL_OPT:
+		case K8S_CLIENT_AUTH_ENABLED_OPT:
+		case K8S_CLIENT_AUTH_CERT_LOCATION_OPT:
+		case K8S_CLIENT_AUTH_KEY_LOCATION_OPT:
+		case K8S_SERVER_CERT_VALIDATION_ENABLED_OPT:
+		case K8S_METADATA_REFRESH_INTERVAL_OPT:
+		case K8S_METADATA_REFRESH_ENABLED_OPT:
 		default:
 			{
 				return fmt.Errorf("unknown log opt '%s' provided for %s log driver\n", key, DRIVER_NAME)

--- a/testserver/docker-compose.yaml
+++ b/testserver/docker-compose.yaml
@@ -4,9 +4,15 @@ x-logging:
   options:
     relpHostname: "127.0.0.1"
     relpPort: "1601"
-    tags: "off"
+    tags: "full"
     syslogHostname: "custom_hostname"
     syslogAppName: "custom_app_name"
+    k8sMetadata: "true"
+    kubeletUrl: "http://localhost:10750"
+    k8sClientAuthEnabled: "false"
+    k8sServerCertValidationEnabled: "false"
+    k8sMetadataRefreshEnabled: "true"
+    k8sMetadataRefreshInterval: "0"
   driver: teragrep/dkr_01:v1
 services:
   test:


### PR DESCRIPTION
In progress PR for resolving issue #9 

Allows user to set various options via log-opts, such as
"k8sMetadata"
"kubeletUrl"
 "k8sClientAuthEnabled"
 "k8sClientAuthCertPath"
"k8sClientAuthKeyPath"
"k8sServerCertValidationEnabled"
 "k8sServerCertPath"
"k8sMetadataRefreshInterval"
 "k8sMetadataRefreshEnabled"

and retrieve pods information from kubernetes
