### PR TITLE
fix k8s metadata not working in minikube, new default log-opts, readme update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,21 +6,21 @@ Docker Logging Driver Plugin. Sends the Docker container's logs to the specified
 == Logging options
 These can be modified via the `--log-opt KEY=VALUE` command-line argument when using `docker run`.
 
-* relpHostname = ip address
-* relpPort = port number
-* relpTls = "true" or "false"
+* relpHostname = ip address (default: 127.0.0.1)
+* relpPort = port number (default: 1601)
+* relpTls = "true" or "false" (default: false)
 * syslogHostname = used for hostname in the syslog message, otherwise actual system hostname
 * syslogAppName = used for app name in the syslog message, otherwise "teragrep"
-* tags = "off", "minimal" or "full", sets additional structured data based on docker log tags
-* k8sMetadata = "true" or "false", fetch kubernetes metadata from specified address
-* kubeletUrl = "https://xxx:12345", provide kubelet address for kubernetes metadata
-* k8sClientAuthEnabled = "true" or "false"
-* k8sClientAuthCertPath = "..."
-* k8sClientAuthKeyPath = "..."
-* k8sServerCertValidationEnabled = "true" or "false"
-* k8sServerCertPath = "..."
-* k8sMetadataRefreshInterval = "0" in seconds
-* k8sMetadataRefreshEnabled = "true" or "false"
+* tags = "off", "minimal" or "full", sets additional structured data based on docker log tags (default: off)
+* k8sMetadata = "true" or "false", fetch kubernetes metadata from specified address (default: false)
+* kubeletUrl = "https://xxx:12345", provide kubelet address for kubernetes metadata (default: https://minikube:10250)
+* k8sClientAuthEnabled = "true" or "false" (default: true)
+* k8sClientAuthCertPath = "..." (default: /var/lib/minikube/certs/apiserver-kubelet-client.crt)
+* k8sClientAuthKeyPath = "..." (default: /var/lib/minikube/certs/apiserver-kubelet-client.key)
+* k8sServerCertValidationEnabled = "true" or "false" (default: false)
+* k8sServerCertPath = "..." (default: none)
+* k8sMetadataRefreshInterval = "0" in seconds (default: 0)
+* k8sMetadataRefreshEnabled = "true" or "false" (default: false)
 
 == Building the plugin
 

--- a/plugin/config.json
+++ b/plugin/config.json
@@ -8,5 +8,13 @@
   },
   "Network": {
     "Type": "host"
-  }
+  },
+  "Mounts": [
+    {
+      "destination": "/var/lib/minikube/certs",
+      "source": "/var/lib/minikube/certs",
+      "type": "none",
+      "options": ["rbind","ro"]
+    }
+  ]
 }

--- a/plugin/driver.go
+++ b/plugin/driver.go
@@ -148,13 +148,13 @@ func (d *Driver) StartLogging(file string, logCtx logger.Info) error {
 		}
 	}
 
-	kubeletUrl := "https://localhost:10250"
+	kubeletUrl := "https://minikube:10250"
 	v, ok = logCtx.Config[KUBELET_URL_OPT]
 	if ok {
 		kubeletUrl = v
 	}
 
-	kubernetesClientAuthEnabled := false
+	kubernetesClientAuthEnabled := true
 	v, ok = logCtx.Config[K8S_CLIENT_AUTH_ENABLED_OPT]
 	if ok {
 		if v == "true" || v == "True" || v == "TRUE" {
@@ -162,13 +162,13 @@ func (d *Driver) StartLogging(file string, logCtx logger.Info) error {
 		}
 	}
 
-	kubernetesClientAuthCertPath := ""
+	kubernetesClientAuthCertPath := "/var/lib/minikube/certs/apiserver-kubelet-client.crt"
 	v, ok = logCtx.Config[K8S_CLIENT_AUTH_CERT_LOCATION_OPT]
 	if ok {
 		kubernetesClientAuthCertPath = v
 	}
 
-	kubernetesClientAuthKeyPath := ""
+	kubernetesClientAuthKeyPath := "/var/lib/minikube/certs/apiserver-kubelet-client.key"
 	v, ok = logCtx.Config[K8S_CLIENT_AUTH_KEY_LOCATION_OPT]
 	if ok {
 		kubernetesClientAuthKeyPath = v
@@ -411,6 +411,9 @@ func consumeLog(lg *logPair) {
 				err := getKubernetesData(lg)
 				if err == nil {
 					lg.lastKubernetesMetadataRefresh = time.Now().Unix()
+				} else {
+					// error getting kubernetes data
+					fmt.Fprintf(os.Stderr, "Error fetching kapi data: %s\n", err.Error())
 				}
 
 			} else if lg.kubernetesMetadataRefreshEnabled {
@@ -423,6 +426,9 @@ func consumeLog(lg *logPair) {
 					err := getKubernetesData(lg)
 					if err == nil {
 						lg.lastKubernetesMetadataRefresh = time.Now().Unix()
+					} else {
+						// error getting kubernetes data
+						fmt.Fprintf(os.Stderr, "Error fetching kapi data: %s\n", err.Error())
 					}
 				}
 			}

--- a/testserver/main.go
+++ b/testserver/main.go
@@ -17,10 +17,10 @@ func main() {
 		fmt.Fprintf(w, "echo %v", r.URL.Path)
 	})
 
-	var port string
-	if port = os.Getenv("HTTP_PORT"); port == "" {
+	var port string = "9003"
+	/*if port = os.Getenv("HTTP_PORT"); port == "" {
 		port = "9000"
-	}
+	}*/
 
 	log.Printf("[TestServer] Start server on %v %v", "localhost", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))


### PR DESCRIPTION
Tested in minikube environment

Found issues:
- k8sMetadata fetching had issues, no certs could be accessed
-> added permissions for plugin (read-only) for the /var/lib/minikube/certs folder, this can be changed in the config.json file.
- when serverValidation was off, InsecureSkipVerify was false meaning it would fail in self-signed certificate error (same as running curl without -k).

Changes:
- better defaults for log-opts
- update README to document those defaults